### PR TITLE
Replace google-map-react

### DIFF
--- a/scottie-is-xxx/blog/about-college-football-opening-weekend-2016/index.md
+++ b/scottie-is-xxx/blog/about-college-football-opening-weekend-2016/index.md
@@ -9,20 +9,18 @@ import getGoogleMapsAPIKey from '../../src/services/googleMapsAPIKeyService'
 import getGoogleMapsOptionsSettings from '../../src/services/googleMapsOptionsService'
 import GoogleMapReact from 'google-map-react'
 import MapMarker from '../../src/components/GoogleMaps/mapMarker'
+import CustomMap from '../../src/components/GoogleMaps/customMap'
 
 ## The Plan
 Before the start of the 2016 college football season, two good friends and I decided to make an epic pilgrimage for the opening weekend. While most games are played on Saturdays, it just so happened that our alma maters played on Friday, Saturday, and Sunday of Labor Day weekend. The three of us all lived in Oklahoma at the time, so we began planning the logistics to see if it would even be physically possible to be at each stadium by kickoff. The match ups were Kansas State at Stanford in Palo Alto, California (for Chris), UCLA at Texas A&M in College Station, Texas (for Callen), and Notre Dame at UT in Austin, Texas (for me). Despite requiring about 4,500 miles of total travel, we determined that it would be possible to see all the games barring any sort of delays. We took a gamble, and this is how it all played out.
 
 ## Thursday, September 1st
 <div style={{ height: '50vh', width: '100%' }}>
-    <GoogleMapReact
-        bootstrapURLKeys={{ key: getGoogleMapsAPIKey() }}
-        defaultCenter={{lat: 32.899800, lng: -97.040636}}
+    <CustomMap
         defaultZoom={9}
-        options={getGoogleMapsOptionsSettings()}
-    >
-    <MapMarker lat={32.899800} lng={-97.040636} />
-    </GoogleMapReact>
+        defaultCenter={{lat: 32.899800, lng: -97.040636}}
+        markers={[{lat: 32.899800, lng: -97.040636}]}
+    />
 </div>
 <br />
 
@@ -30,14 +28,11 @@ The journey began with a five-hour drive from northern Oklahoma to a hotel adjac
 
 ## Friday, September 2nd
 <div style={{ height: '50vh', width: '100%' }}>
-    <GoogleMapReact
-        bootstrapURLKeys={{ key: getGoogleMapsAPIKey() }}
-        defaultCenter={{lat: 37.712384, lng: -122.218832}}
+    <CustomMap
         defaultZoom={9}
-        options={getGoogleMapsOptionsSettings()}
-    >
-    <MapMarker lat={37.712384} lng={-122.218832} />
-    </GoogleMapReact>
+        defaultCenter={{lat: 37.712384, lng: -122.218832}}
+        markers={[{lat: 37.712384, lng: -122.218832}]}
+    />
 </div>
 <br />
 
@@ -62,14 +57,11 @@ After the very solid matchup, we took an Uber from Palo Alto back to San Francis
 ## Saturday, September 3rd
 
 <div style={{ height: '50vh', width: '100%' }}>
-    <GoogleMapReact
-        bootstrapURLKeys={{ key: getGoogleMapsAPIKey() }}
-        defaultCenter={{lat: 30.619470, lng: -96.338035}}
+    <CustomMap
         defaultZoom={9}
-        options={getGoogleMapsOptionsSettings()}
-    >
-    <MapMarker lat={30.619470} lng={-96.338035} />
-    </GoogleMapReact>
+        defaultCenter={{lat: 30.619470, lng: -96.338035}}
+        markers={[{lat: 30.619470, lng: -96.338035}]}
+    />
 </div>
 <br />
 
@@ -93,14 +85,11 @@ As much as I would have liked to check out the local scene, we ate Buffalo Wild 
 
 ## Sunday, September 4th
 <div style={{ height: '50vh', width: '100%' }}>
-    <GoogleMapReact
-        bootstrapURLKeys={{ key: getGoogleMapsAPIKey() }}
-        defaultCenter={{lat: 30.283983, lng: -97.732759}}
+    <CustomMap
         defaultZoom={9}
-        options={getGoogleMapsOptionsSettings()}
-    >
-    <MapMarker lat={30.283983} lng={-97.732759} />
-    </GoogleMapReact>
+        defaultCenter={{lat: 30.283983, lng: -97.732759}}
+        markers={[{lat: 30.283983, lng: -97.732759}]}
+    />
 </div>
 <br />
 

--- a/scottie-is-xxx/blog/about-college-football-opening-weekend-2016/index.md
+++ b/scottie-is-xxx/blog/about-college-football-opening-weekend-2016/index.md
@@ -5,10 +5,6 @@ date: "2016-11-06"
 description: "An epic trip to start the season."
 tags: ["Travel"]
 ---
-import getGoogleMapsAPIKey from '../../src/services/googleMapsAPIKeyService'
-import getGoogleMapsOptionsSettings from '../../src/services/googleMapsOptionsService'
-import GoogleMapReact from 'google-map-react'
-import MapMarker from '../../src/components/GoogleMaps/mapMarker'
 import CustomMap from '../../src/components/GoogleMaps/customMap'
 
 ## The Plan

--- a/scottie-is-xxx/blog/travel-diary-japan-2016/index.md
+++ b/scottie-is-xxx/blog/travel-diary-japan-2016/index.md
@@ -5,21 +5,15 @@ date: "2016-06-05"
 description: "A detailed log from my second journey to Japan."
 tags: ["Travel"]
 ---
-import getGoogleMapsAPIKey from '../../src/services/googleMapsAPIKeyService'
-import getGoogleMapsOptionsSettings from '../../src/services/googleMapsOptionsService'
-import GoogleMapReact from 'google-map-react'
-import MapMarker from '../../src/components/GoogleMaps/mapMarker'
+import CustomMap from '../../src/components/GoogleMaps/customMap'
 
 ## April 30th, 2016 - 電車の風 - Tokyo
 <div style={{ height: '50vh', width: '100%' }}>
-    <GoogleMapReact
-        bootstrapURLKeys={{ key: getGoogleMapsAPIKey() }}
-        defaultCenter={{lat: 35.772230, lng: 140.392904}}
+    <CustomMap
         defaultZoom={7}
-        options={getGoogleMapsOptionsSettings()}
-    >
-    <MapMarker lat={35.772230} lng={140.392904} />
-    </GoogleMapReact>
+        defaultCenter={{lat: 35.772230, lng: 140.392904}}
+        markers={[{lat: 35.772230, lng: 140.392904}]}
+    />
 </div>
 <br />
 
@@ -31,14 +25,11 @@ We all purchased our tickets and awaited the Skyliner express train. Right on sc
 
 ## May 1st, 2016 - Nooks and Crannies - Tokyo
 <div style={{ height: '50vh', width: '100%' }}>
-    <GoogleMapReact
-        bootstrapURLKeys={{ key: getGoogleMapsAPIKey() }}
-        defaultCenter={{lat: 35.710324, lng: 139.810657}}
+    <CustomMap
         defaultZoom={9}
-        options={getGoogleMapsOptionsSettings()}
-    >
-    <MapMarker lat={35.710324} lng={139.810657} />
-    </GoogleMapReact>
+        defaultCenter={{lat: 35.710324, lng: 139.810657}}
+        markers={[{lat: 35.710324, lng: 139.810657}]}
+    />
 </div>
 <br />
 
@@ -54,14 +45,11 @@ That’s not to say that you're never exposed to copious amount of people. From 
 
 ## May 2nd, 2016 - Sea of Trees - Aokigahara
 <div style={{ height: '50vh', width: '100%' }}>
-    <GoogleMapReact
-        bootstrapURLKeys={{ key: getGoogleMapsAPIKey() }}
-        defaultCenter={{lat: 35.491928, lng: 138.682636}}
+    <CustomMap
         defaultZoom={7}
-        options={getGoogleMapsOptionsSettings()}
-    >
-    <MapMarker lat={35.491928} lng={138.682636} />
-    </GoogleMapReact>
+        defaultCenter={{lat: 35.491928, lng: 138.682636}}
+        markers={[{lat: 35.491928, lng: 138.682636}]}
+    />
 </div>
 <br />
 
@@ -95,14 +83,11 @@ We decided to follow the tissues. Honestly, I hadn't taken into consideration wh
 
 ## May 3rd, 2016 - Change of Pace - Chiba
 <div style={{ height: '50vh', width: '100%' }}>
-    <GoogleMapReact
-        bootstrapURLKeys={{ key: getGoogleMapsAPIKey() }}
-        defaultCenter={{lat: 35.644085, lng: 140.04023}}
+    <CustomMap
         defaultZoom={7}
-        options={getGoogleMapsOptionsSettings()}
-    >
-    <MapMarker lat={35.644085} lng={140.04023} />
-    </GoogleMapReact>
+        defaultCenter={{lat: 35.644085, lng: 140.04023}}
+        markers={[{lat: 35.644085, lng: 140.04023}]}
+    />
 </div>
 <br />
 
@@ -112,14 +97,11 @@ I had the pleasure of seeing two of my favorite bands that I frequently listened
 
 ## May 4th-5th, 2016 - The Old City - Kyoto
 <div style={{ height: '50vh', width: '100%' }}>
-    <GoogleMapReact
-        bootstrapURLKeys={{ key: getGoogleMapsAPIKey() }}
-        defaultCenter={{lat: 35.012881, lng: 135.677749}}
+    <CustomMap
         defaultZoom={8}
-        options={getGoogleMapsOptionsSettings()}
-    >
-    <MapMarker lat={35.012881} lng={135.677749} />
-    </GoogleMapReact>
+        defaultCenter={{lat: 35.012881, lng: 135.677749}}
+        markers={[{lat: 35.012881, lng: 135.677749}]}
+    />
 </div>
 <br />
 
@@ -143,14 +125,11 @@ The next day was mostly reserved for traveling. From Kyoto Station, we went to K
 
 ## May 5th-8th, 2016 - Texas in the Pacific - Okinawa
 <div style={{ height: '50vh', width: '100%' }}>
-    <GoogleMapReact
-        bootstrapURLKeys={{ key: getGoogleMapsAPIKey() }}
-        defaultCenter={{lat: 26.699348, lng: 127.902083}}
+    <CustomMap
         defaultZoom={7}
-        options={getGoogleMapsOptionsSettings()}
-    >
-    <MapMarker lat={26.699348} lng={127.902083} />
-    </GoogleMapReact>
+        defaultCenter={{lat: 26.699348, lng: 127.902083}}
+        markers={[{lat: 26.699348, lng: 127.902083}]}
+    />
 </div>
 <br />
 

--- a/scottie-is-xxx/package.json
+++ b/scottie-is-xxx/package.json
@@ -21,6 +21,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@mdx-js/react": "^3.1.0",
+    "@vis.gl/react-google-maps": "^1.5.1",
     "clsx": "^2.1.1",
     "d3": "^7.9.0",
     "google-map-react": "^2.2.1",

--- a/scottie-is-xxx/package.json
+++ b/scottie-is-xxx/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@docusaurus/core": "3.7.0",
     "@docusaurus/preset-classic": "3.7.0",
+    "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/free-brands-svg-icons": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",

--- a/scottie-is-xxx/package.json
+++ b/scottie-is-xxx/package.json
@@ -24,7 +24,6 @@
     "@vis.gl/react-google-maps": "^1.5.1",
     "clsx": "^2.1.1",
     "d3": "^7.9.0",
-    "google-map-react": "^2.2.1",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/scottie-is-xxx/src/components/GoogleMaps/customMap.js
+++ b/scottie-is-xxx/src/components/GoogleMaps/customMap.js
@@ -1,0 +1,20 @@
+import React from "react"
+import getGoogleMapsAPIKey from '../../services/googleMapsAPIKeyService.js'
+import getGoogleMapsOptionsSettings from '../../services/googleMapsOptionsService.js'
+import GoogleMapReact from 'google-map-react'
+import MapMarker from './mapMarker.js'
+
+export default function({ defaultZoom, defaultCenter, markers }) {
+    return (
+        <GoogleMapReact
+            bootstrapURLKeys={{ key: getGoogleMapsAPIKey() }}
+            defaultCenter={defaultCenter}
+            defaultZoom={defaultZoom}
+            options={getGoogleMapsOptionsSettings()}
+        >
+            {markers.map(({lat, lng}) => (
+                <MapMarker key={lat} lat={lat} lng={lng} />
+            ))}
+        </GoogleMapReact>
+    )
+}

--- a/scottie-is-xxx/src/components/GoogleMaps/customMap.js
+++ b/scottie-is-xxx/src/components/GoogleMaps/customMap.js
@@ -1,20 +1,21 @@
 import React from "react"
 import getGoogleMapsAPIKey from '../../services/googleMapsAPIKeyService.js'
 import getGoogleMapsOptionsSettings from '../../services/googleMapsOptionsService.js'
-import GoogleMapReact from 'google-map-react'
-import MapMarker from './mapMarker.js'
+import { Marker, APIProvider, Map } from '@vis.gl/react-google-maps';
 
 export default function({ defaultZoom, defaultCenter, markers }) {
+    const { styles } = getGoogleMapsOptionsSettings();
     return (
-        <GoogleMapReact
-            bootstrapURLKeys={{ key: getGoogleMapsAPIKey() }}
-            defaultCenter={defaultCenter}
-            defaultZoom={defaultZoom}
-            options={getGoogleMapsOptionsSettings()}
-        >
-            {markers.map(({lat, lng}) => (
-                <MapMarker key={lat} lat={lat} lng={lng} />
-            ))}
-        </GoogleMapReact>
+        <APIProvider apiKey={getGoogleMapsAPIKey()}>
+            <Map
+                defaultCenter={defaultCenter}
+                defaultZoom={defaultZoom}
+                styles={styles}
+            >
+                {markers.map(({ lat, lng }, i) => (
+                    <Marker key={i} position={{ lat, lng }} />
+                ))}
+            </Map>
+        </APIProvider>
     )
 }


### PR DESCRIPTION
# Summary

PR does two things:

1. Create a modular ``CustomMap` component to reduce duplicated code across blogs that import the map component.
2. Replace `google-map-react` with `@viz.gl/react-google-maps`.

Tested using `npm run build` and `npm start` to verify that project does successfully build.

# For Review

* [x] Review naming convention of custom map component, change if necessary
* [x] ensure that google map styling remains consistent to the way it looked before
* [x] ensure proper API credentials are used; that it is not leaked to the console
 